### PR TITLE
Remove the command that publishes view

### DIFF
--- a/src/BraintreePaymentsServiceProvider.php
+++ b/src/BraintreePaymentsServiceProvider.php
@@ -17,12 +17,7 @@ class BraintreePaymentsServiceProvider extends ServiceProvider
 	 * @return void
 	 */
 	public function boot()
-	{
-		$this->loadViewsFrom(__DIR__ . '/../resources/views', 'symless/braintree-payments');
-
-		$this->publishes([
-			__DIR__ . '/../resources/views' => base_path('resources/views/vendor/symless/braintree-payments'),
-		]);
+	{	
 	}
 
 	/**


### PR DESCRIPTION
There are no views for this package when running `php artisan view:cache`, it gives error
```
The "/var/www/html/vendor/symless/braintree-payments/src/../resources/views" directory does not exist. {"exception":"[object] (Symfony\\Component\\Finder\\Exception\\DirectoryNotFoundException(code: 0): The \"/var/www/html/vendor/symless/braintree-payments/src/../resources/views\" directory does not exist. at /var/www/html/vendor/symfony/finder/Finder.php:602)
```